### PR TITLE
fix: Do not evaluate all matcher when the first is false

### DIFF
--- a/src/MockHttp/Extensions/HttpRequestMatcherExtensions.cs
+++ b/src/MockHttp/Extensions/HttpRequestMatcherExtensions.cs
@@ -13,18 +13,15 @@ internal static class HttpRequestMatcherExtensions
     /// <returns><see langword="true" /> if all <paramref name="matchers" /> match the <paramref name="requestContext" />.</returns>
     public static async Task<bool> AllAsync(this IEnumerable<IAsyncHttpRequestMatcher> matchers, MockHttpRequestContext requestContext)
     {
-        bool hasMatchedAll = true;
         foreach (IAsyncHttpRequestMatcher m in matchers)
         {
-            if (await m.IsMatchAsync(requestContext).ConfigureAwait(false))
+            if (!await m.IsMatchAsync(requestContext).ConfigureAwait(false))
             {
-                continue;
+                return false;
             }
-
-            hasMatchedAll = false;
         }
 
-        return hasMatchedAll;
+        return true;
     }
 
     /// <summary>

--- a/test/MockHttp.Json.Tests/JsonRequestMatchingExtensionTests.cs
+++ b/test/MockHttp.Json.Tests/JsonRequestMatchingExtensionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Text;
+using FluentAssertions;
 using MockHttp.FluentAssertions;
 using MockHttp.Json.Newtonsoft;
 using Newtonsoft.Json;
@@ -33,6 +34,24 @@ public class JsonRequestMatchingExtensionTests
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.OK);
+    }
+    
+    [Fact]
+    public async Task Given_not_a_json_content_matching_request_and_a_different_request_uri_when_matching_should_not_test_others_matcher()
+    {
+        var obj = new TestClass { SomeProperty = "value" };
+
+        _httpMock
+            .When(m => m
+                .RequestUri("/users")
+                .JsonContent(obj))
+            .Respond(HttpStatusCode.OK);
+
+        // Act
+        Func<Task> act = () => _httpClient.PostAsync("http://0.0.0.0", new StringContent("test=test", Encoding.UTF8, "application/x-www-form-urlencoded"));
+
+        // Assert
+        await act.Should().NotThrowAsync<System.Text.Json.JsonException>();
     }
 
     [Theory]


### PR DESCRIPTION
I have this use case in my code :

- A call to API with url encoded string content 
- A call to API with a Json content

I wan to verify/mock the API with Json. And I have an exception on the json deserializer. But my second API have not the same uri. 
Why to evaluate other matcher ? If the first is false ?