### PR TITLE
Add timeout exception for .NET 5 or greater targets.

### DIFF
--- a/src/MockHttp/Responses/TimeoutBehavior.cs
+++ b/src/MockHttp/Responses/TimeoutBehavior.cs
@@ -1,4 +1,6 @@
-﻿namespace MockHttp.Responses;
+﻿using System.Runtime.InteropServices;
+
+namespace MockHttp.Responses;
 
 internal sealed class TimeoutBehavior
     : IResponseBehavior
@@ -26,8 +28,10 @@ internal sealed class TimeoutBehavior
             .ContinueWith(_ =>
                 {
                     var tcs = new TaskCompletionSource<HttpResponseMessage>();
-#if NET5_0_OR_GREATER
-                    if (!cancellationToken.IsCancellationRequested)
+#if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER)
+                    bool isNetCore3 = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 3", StringComparison.OrdinalIgnoreCase); // Shim for .NET 5 being EOL and no longer producing an assembly for it.
+
+                    if (!cancellationToken.IsCancellationRequested && !isNetCore3)
                     {
                         tcs.TrySetException(new TaskCanceledException(null, new TimeoutException()));
                     }

--- a/test/MockHttp.Tests/Responses/TimeoutBehaviorTests.cs
+++ b/test/MockHttp.Tests/Responses/TimeoutBehaviorTests.cs
@@ -21,7 +21,13 @@ public class TimeoutBehaviorTests
 
         // Assert
         sw.Start();
+
+#if NET5_0_OR_GREATER
+        await act.Should().ThrowAsync<TaskCanceledException>().WithInnerException(typeof(TimeoutException), "the timeout expired");
+#else
         await act.Should().ThrowAsync<TaskCanceledException>("the timeout expired");
+#endif
+
         sw.Elapsed.Should()
             // Allow 5% diff.
             .BeGreaterThan(timeout - TimeSpan.FromMilliseconds(timeoutInMilliseconds * 0.95));
@@ -41,7 +47,7 @@ public class TimeoutBehaviorTests
         Func<Task> act = () => sut.HandleAsync(new MockHttpRequestContext(new HttpRequestMessage()), new HttpResponseMessage(), next.Object, ct);
 
         // Assert
-        await act.Should().ThrowAsync<TaskCanceledException>();
+        await act.Should().ThrowAsync<TaskCanceledException>().Where(ex => ex.InnerException == null);
         sw.Elapsed.Should().BeLessThan(timeout);
         next.VerifyNoOtherCalls();
     }


### PR DESCRIPTION
Closes #49 .