### PR TITLE
fix: .NET Standard 2.0 was not covered. 

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,5 +19,6 @@ jobs:
             6.0.x
             5.0.x
             3.1.x
+            2.1.x
 
       - run: dotnet test -c Release

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,7 @@ jobs:
             6.0.x
             5.0.x
             3.1.x
+            2.1.x
 
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <NetTestSdkVersion>17.5.0</NetTestSdkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework)=='netcoreapp2.1'">
+    <NetTestSdkVersion>17.3.3</NetTestSdkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(NetTestSdkVersion)" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(NetTestSdkVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/MockHttp.Json.Tests/MockHttp.Json.Tests.csproj
+++ b/test/MockHttp.Json.Tests/MockHttp.Json.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -10,14 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MockHttp.Testing\MockHttp.Testing.csproj" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=net48" Condition="'$(TargetFramework)'=='net48'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
-    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
-
+    <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MockHttp.Testing/MockHttp.Testing.csproj
+++ b/test/MockHttp.Testing/MockHttp.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>false</IsTestProject>
 
@@ -14,13 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=net48" Condition="'$(TargetFramework)'=='net48'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
-    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
+    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MockHttp.Tests/MockHttp.Tests.csproj
+++ b/test/MockHttp.Tests/MockHttp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 


### PR DESCRIPTION
Closes #51 

Added .NET Core 2.1 to test target framework .NET Std 2.0. Requires downgrading some NuGet test dependencies.