### PR TITLE
ci(deps): bump SonarScanner dependencies

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,6 +27,15 @@ jobs:
             3.1.x
             2.1.x
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'   
+          
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner
 


### PR DESCRIPTION
Fixes PR decoration message

```
warning The version of Java (11.0.20) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
```

https://docs.sonarcloud.io/appendices/scanner-environment/