### PR TITLE
fix: data escaped space (+) was not parsing into space char.

### DIFF
--- a/src/MockHttp/Http/DataEscapingHelper.cs
+++ b/src/MockHttp/Http/DataEscapingHelper.cs
@@ -34,8 +34,8 @@ internal static class DataEscapingHelper
                     throw new FormatException("The escaped data string format is invalid.");
                 }
 
-                string key = Uri.UnescapeDataString(kvp[0]);
-                string? value = kvp.Length > 1 ? Uri.UnescapeDataString(kvp[1]) : null;
+                string key = UnescapeData(kvp[0]);
+                string? value = kvp.Length > 1 ? UnescapeData(kvp[1]) : null;
                 return new KeyValuePair<string, string?>(key, value);
             })
             // Group values for same key.
@@ -46,6 +46,11 @@ internal static class DataEscapingHelper
                     .Where(v => v is not null)!)
             )
             .ToList();
+    }
+
+    private static string UnescapeData(string v)
+    {
+        return Uri.UnescapeDataString(v).Replace('+', ' ');
     }
 
     internal static string Format(IEnumerable<KeyValuePair<string, string>> items)

--- a/test/MockHttp.Tests/Http/DataEscapingHelperTests.cs
+++ b/test/MockHttp.Tests/Http/DataEscapingHelperTests.cs
@@ -44,7 +44,25 @@ public class DataEscapingHelperTests
         var expected = new Dictionary<string, IEnumerable<string>> { { "key", new[] { "value", "$%^ &*", "another value" } } };
 
         // Act
-        IEnumerable<KeyValuePair<string, IEnumerable<string>>> actual = DataEscapingHelper.Parse("key=value&key=%24%25%5E%20%26%2A&key=another%20value");
+        IEnumerable<KeyValuePair<string, IEnumerable<string>>> actual = DataEscapingHelper.Parse("key=value&key=%24%25%5E+%26%2A&key=another%20value");
+
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Theory]
+    [InlineData("key", "key", "a%20b", "a b")]
+    [InlineData("key", "key", "a+b", "a b")]
+    [InlineData("key", "key", "a b", "a b")]
+    [InlineData("a%20b", "a b", "value", "value")]
+    [InlineData("a+b", "a b", "value", "value")]
+    [InlineData("a b", "a b", "value", "value")]
+    public void Given_escapedString_contains_space_when_parsing_it_should_return_expected(string key, string expectedKey, string value, string expectedValue)
+    {
+        var expected = new Dictionary<string, IEnumerable<string>> { { expectedKey, new[] { expectedValue } } };
+
+        // Act
+        IEnumerable<KeyValuePair<string, IEnumerable<string>>> actual = DataEscapingHelper.Parse($"{key}={value}");
 
         // Assert
         actual.Should().BeEquivalentTo(expected);


### PR DESCRIPTION
Spaces escaped as `+` sign should be parsed into space character allowing the form data matcher to pass.

Fixes #63