### PR TITLE
Address several static code analysis warnings

### DIFF
--- a/src/MockHttp.Json/SystemTextJson/JsonDocumentEqualityComparer.cs
+++ b/src/MockHttp.Json/SystemTextJson/JsonDocumentEqualityComparer.cs
@@ -51,7 +51,7 @@ internal sealed class JsonDocumentEqualityComparer
             JsonValueKind.False => true,
             JsonValueKind.True => true,
             JsonValueKind.String => left.ValueEquals(right.GetString()),
-            JsonValueKind.Number => left.GetRawText().Equals(right.GetRawText()),
+            JsonValueKind.Number => string.Equals(left.GetRawText(), right.GetRawText(), StringComparison.Ordinal),
             JsonValueKind.Array => ArrayEquals(left, right, serializerOptions),
             JsonValueKind.Object => ObjectEquals(left, right, serializerOptions),
             _ => false

--- a/src/MockHttp.Json/SystemTextJson/SystemTextJsonEqualityComparer.cs
+++ b/src/MockHttp.Json/SystemTextJson/SystemTextJsonEqualityComparer.cs
@@ -51,6 +51,10 @@ internal sealed class SystemTextJsonEqualityComparer
 
     public int GetHashCode(string obj)
     {
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        return obj.GetHashCode(StringComparison.Ordinal);
+#else
         return obj.GetHashCode();
+#endif
     }
 }

--- a/src/MockHttp.Server/Server/ServerRequestHandler.cs
+++ b/src/MockHttp.Server/Server/ServerRequestHandler.cs
@@ -42,7 +42,9 @@ internal class ServerRequestHandler : DelegatingHandler
         {
             LogRequestMessage(httpContext, Resources.Error_VerifyMockSetup);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
             httpResponseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+#pragma warning restore CA2000 // Dispose objects before losing scope
             {
                 ReasonPhrase = Resources.Error_VerifyMockSetup,
                 Content = new StringContent(Resources.Error_VerifyMockSetup + Environment.NewLine + ex, MockHttpHandler.DefaultEncoding, MediaTypes.PlainText)

--- a/src/MockHttp/Extensions/ResponseBuilderExtensions.cs
+++ b/src/MockHttp/Extensions/ResponseBuilderExtensions.cs
@@ -201,7 +201,7 @@ public static class ResponseBuilderExtensions
 
         return builder.Body(async token =>
         {
-            Stream stream = await streamContentFactory(token);
+            Stream stream = await streamContentFactory(token).ConfigureAwait(false);
             if (!stream.CanRead)
             {
                 throw new InvalidOperationException("Cannot read from stream.");

--- a/src/MockHttp/Http/DataEscapingHelper.cs
+++ b/src/MockHttp/Http/DataEscapingHelper.cs
@@ -50,7 +50,11 @@ internal static class DataEscapingHelper
 
     private static string UnescapeData(string v)
     {
-        return Uri.UnescapeDataString(v?.Replace("+", "%20")!);
+        return Uri.UnescapeDataString(v?.Replace("+", "%20"
+#if NET7_0_OR_GREATER || NETSTANDARD2_1
+                , StringComparison.Ordinal
+#endif
+            )!);
     }
 
     internal static string Format(IEnumerable<KeyValuePair<string, string>> items)

--- a/src/MockHttp/Http/HttpHeadersCollection.cs
+++ b/src/MockHttp/Http/HttpHeadersCollection.cs
@@ -4,6 +4,9 @@ namespace MockHttp.Http;
 
 internal sealed class HttpHeadersCollection : HttpHeaders
 {
+    private static readonly char[] HeaderKeyValueSeparator = new[] { ':' };
+    private static readonly char[] HeaderValueSeparator = new[] { ',' };
+
     public HttpHeadersCollection()
     {
     }
@@ -43,7 +46,7 @@ internal sealed class HttpHeadersCollection : HttpHeaders
                 continue;
             }
 
-            string[] hvp = header.Split(new[] { ':' }, 2, StringSplitOptions.None);
+            string[] hvp = header.Split(HeaderKeyValueSeparator, 2, StringSplitOptions.None);
 
             string fieldName = hvp.Length > 0 ? hvp[0] : string.Empty;
             string? fieldValue = hvp.Length > 1 ? hvp[1] : null;
@@ -61,7 +64,7 @@ internal sealed class HttpHeadersCollection : HttpHeaders
         }
 
         return headerValue
-            .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+            .Split(HeaderValueSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Select(v => v.Trim())
             .Where(v => v.Length > 0)
             .ToArray();

--- a/src/MockHttp/Matchers/ContentMatcher.cs
+++ b/src/MockHttp/Matchers/ContentMatcher.cs
@@ -47,7 +47,7 @@ public class ContentMatcher : IAsyncHttpRequestMatcher
     /// Gets the expected content in bytes.
     /// </summary>
     // ReSharper disable once MemberCanBeProtected.Global
-    protected internal byte[] ByteContent { get; }
+    protected internal IReadOnlyList<byte> ByteContent { get; }
 
     /// <inheritdoc />
     public Task<bool> IsMatchAsync(MockHttpRequestContext requestContext)
@@ -71,10 +71,10 @@ public class ContentMatcher : IAsyncHttpRequestMatcher
 
             if (requestContent is null)
             {
-                return ByteContent.Length == 0;
+                return ByteContent.Count == 0;
             }
 
-            if (requestContent.Length == 0 && ByteContent.Length == 0)
+            if (requestContent.Length == 0 && ByteContent.Count == 0)
             {
                 return true;
             }
@@ -99,17 +99,17 @@ public class ContentMatcher : IAsyncHttpRequestMatcher
     /// <inheritdoc />
     public override string ToString()
     {
-        if (ByteContent.Length == 0)
+        if (ByteContent.Count == 0)
         {
             return "Content: <empty>";
         }
 
         if (_encoding is not null)
         {
-            return $"Content: {_encoding.GetString(ByteContent, 0, ByteContent.Length)}";
+            return $"Content: {_encoding.GetString((byte[])ByteContent, 0, ByteContent.Count)}";
         }
 
-        int charsToOutput = Math.Min(MaxBytesDisplayed, ByteContent.Length);
+        int charsToOutput = Math.Min(MaxBytesDisplayed, ByteContent.Count);
         var sb = new StringBuilder();
         sb.Append("Content: [");
         for (int i = 0; i < charsToOutput; i++)
@@ -121,9 +121,9 @@ public class ContentMatcher : IAsyncHttpRequestMatcher
             }
         }
 
-        if (charsToOutput < ByteContent.Length)
+        if (charsToOutput < ByteContent.Count)
         {
-            sb.AppendFormat(CultureInfo.InvariantCulture, ",...](Size = {0})", ByteContent.Length);
+            sb.AppendFormat(CultureInfo.InvariantCulture, ",...](Size = {0})", ByteContent.Count);
         }
         else
         {

--- a/src/MockHttp/Matchers/PartialContentMatcher.cs
+++ b/src/MockHttp/Matchers/PartialContentMatcher.cs
@@ -15,7 +15,7 @@ public class PartialContentMatcher : ContentMatcher
     public PartialContentMatcher(string content, Encoding? encoding)
         : base(content, encoding)
     {
-        if (ByteContent.Length == 0)
+        if (ByteContent.Count == 0)
         {
             throw new ArgumentException("Content can not be empty.", nameof(content));
         }
@@ -28,7 +28,7 @@ public class PartialContentMatcher : ContentMatcher
     public PartialContentMatcher(byte[] content)
         : base(content)
     {
-        if (ByteContent.Length == 0)
+        if (ByteContent.Count == 0)
         {
             throw new ArgumentException("Content can not be empty.", nameof(content));
         }

--- a/src/MockHttp/MockHttpHandler.cs
+++ b/src/MockHttp/MockHttpHandler.cs
@@ -241,7 +241,7 @@ public sealed class MockHttpHandler : HttpMessageHandler, IMockConfiguration
             .Cast<InvokedHttpRequest>()
             .Where(r => !r.IsVerified)
             .ToList();
-        if (!unverifiedRequests.Any())
+        if (unverifiedRequests.Count == 0)
         {
             return;
         }
@@ -270,7 +270,7 @@ public sealed class MockHttpHandler : HttpMessageHandler, IMockConfiguration
         var expectedInvocations = verifiableSetups
             .Where(setup => !setup.VerifyIfInvoked())
             .ToList();
-        if (!expectedInvocations.Any())
+        if (expectedInvocations.Count == 0)
         {
             return;
         }

--- a/src/MockHttp/MockHttpHandler.cs
+++ b/src/MockHttp/MockHttpHandler.cs
@@ -14,9 +14,9 @@ namespace MockHttp;
 /// </summary>
 public sealed class MockHttpHandler : HttpMessageHandler, IMockConfiguration
 {
-    private readonly ConcurrentCollection<HttpCall> _setups;
-    private readonly HttpCall _fallbackSetup;
-    private readonly IDictionary<Type, object> _items;
+    private readonly ConcurrentCollection<HttpCall> _setups = new();
+    private readonly HttpCall _fallbackSetup = new();
+    private readonly Dictionary<Type, object> _items = new();
     private readonly ReadOnlyDictionary<Type, object> _readOnlyItems;
 
     /// <summary>
@@ -29,12 +29,9 @@ public sealed class MockHttpHandler : HttpMessageHandler, IMockConfiguration
     /// </summary>
     public MockHttpHandler()
     {
-        _setups = new ConcurrentCollection<HttpCall>();
         InvokedRequests = new InvokedHttpRequestCollection(this);
-        _items = new Dictionary<Type, object>();
         _readOnlyItems = new ReadOnlyDictionary<Type, object>(_items);
 
-        _fallbackSetup = new HttpCall();
         Fallback = new FallbackRequestSetupPhrase(_fallbackSetup);
         Reset();
     }

--- a/src/MockHttp/NetworkLatency.cs
+++ b/src/MockHttp/NetworkLatency.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using MockHttp.Threading;
 
 namespace MockHttp;
@@ -17,7 +16,9 @@ public class NetworkLatency
     static NetworkLatency()
     {
         // Warmup so that actual simulated latency is more accurate.
+#pragma warning disable CA5394 // Do not use insecure randomness - justification: not used in secure context
         Random.Next();
+#pragma warning restore CA5394 // Do not use insecure randomness
     }
 
     private NetworkLatency(Func<TimeSpan> factory, string name)
@@ -111,7 +112,9 @@ public class NetworkLatency
 
         return new NetworkLatency(() =>
             {
+#pragma warning disable CA5394 // Do not use insecure randomness - justification: not used in secure context
                 double randomLatency = Random.Next(minMs, maxMs);
+#pragma warning restore CA5394
                 return TimeSpan.FromMilliseconds(randomLatency);
             },
             name);

--- a/src/MockHttp/RequestMatching.cs
+++ b/src/MockHttp/RequestMatching.cs
@@ -70,7 +70,7 @@ public class RequestMatching : IFluentInterface
             .Where(m => m.GetType() == matcher.GetType())
             .ToList();
 
-        if ((matcher.IsExclusive && sameTypeMatchers.Any()) || (!matcher.IsExclusive && sameTypeMatchers.Any(m => m.IsExclusive)))
+        if ((matcher.IsExclusive && sameTypeMatchers.Count > 0) || (!matcher.IsExclusive && sameTypeMatchers.Any(m => m.IsExclusive)))
         {
             throw new InvalidOperationException($"Cannot add matcher, another matcher of type '{matcher.GetType().FullName}' already is configured.");
         }

--- a/src/MockHttp/Responses/HttpHeaderBehavior.cs
+++ b/src/MockHttp/Responses/HttpHeaderBehavior.cs
@@ -7,7 +7,7 @@ internal sealed class HttpHeaderBehavior
     : IResponseBehavior
 {
     //https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-    private static readonly ISet<string> HeadersWithSingleValueOnly = new HashSet<string>
+    private static readonly HashSet<string> HeadersWithSingleValueOnly = new()
     {
         // TODO: expand this list.
         HeaderNames.Age,

--- a/src/MockHttp/Threading/ConcurrentCollection.cs
+++ b/src/MockHttp/Threading/ConcurrentCollection.cs
@@ -76,7 +76,9 @@ internal class ConcurrentCollection<T> : IConcurrentReadOnlyCollection<T>
                 if (_items is null)
                 {
 #pragma warning disable S112
+#pragma warning disable CA2201 // Do not raise reserved exception types
                     throw new IndexOutOfRangeException();
+#pragma warning restore CA2201 // Do not raise reserved exception types
 #pragma warning restore S112
                 }
 

--- a/test/MockHttp.Server.Tests/Fixtures/MockHttpServerFixture.cs
+++ b/test/MockHttp.Server.Tests/Fixtures/MockHttpServerFixture.cs
@@ -29,7 +29,15 @@ public class MockHttpServerFixture : IDisposable, IAsyncLifetime
             .CreateLogger();
         LoggerFactory = new SerilogLoggerFactory(logger);
         Handler = new MockHttpHandler();
-        Server = new MockHttpServer(Handler, LoggerFactory, SupportsIpv6() ? $"{scheme}://[::1]:0" : $"{scheme}://127.0.0.1:0");
+        Server = new MockHttpServer(
+            Handler,
+            LoggerFactory,
+            new Uri(
+                SupportsIpv6()
+                    ? $"{scheme}://[::1]:0"
+                    : $"{scheme}://127.0.0.1:0"
+            )
+        );
         Server
             .Configure(builder => builder
                 .Use((_, next) =>

--- a/test/MockHttp.Server.Tests/MockHttpServerTests.cs
+++ b/test/MockHttp.Server.Tests/MockHttpServerTests.cs
@@ -11,6 +11,8 @@ namespace MockHttp;
 [Collection(nameof(DisableParallelization))]
 public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, IDisposable
 {
+    private static readonly Uri BaseUri = new("http://127.0.0.1:0");
+
     private readonly MockHttpServerFixture _fixture;
     private readonly ITestOutputHelper _testOutputHelper;
 
@@ -247,7 +249,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
 
         // Act
 #pragma warning disable CS8604
-        Func<MockHttpServer> act = () => new MockHttpServer(mockHttpHandler, "");
+        Func<MockHttpServer> act = () => new MockHttpServer(mockHttpHandler, BaseUri);
 #pragma warning restore CS8604
 
         // Assert
@@ -261,7 +263,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
 
         // Act
         // ReSharper disable once ExpressionIsAlwaysNull
-        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), loggerFactory, "http://127.0.0.1:0");
+        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), loggerFactory, BaseUri);
 
         // Assert
         using MockHttpServer server = act.Should().NotThrow().Which;
@@ -270,6 +272,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     }
 
     [Fact]
+    [Obsolete("Removed in next major version.")]
     public void When_creating_server_with_null_host_it_should_throw()
     {
         string? hostUrl = null;
@@ -284,6 +287,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     }
 
     [Fact]
+    [Obsolete("Removed in next major version.")]
     public void When_creating_server_with_invalid_host_it_should_throw()
     {
         const string hostUrl = "relative/uri/is/invalid";
@@ -297,9 +301,10 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     }
 
     [Fact]
-    public void When_creating_server_with_absolute_uri_it_should_not_throw_and_take_host_from_uri()
+    [Obsolete("Removed in next major version.")]
+    public void When_creating_server_with_absolute_uri_it_should_not_throw_and_take_host_from_url()
     {
-        const string hostUrl = "https://relative:789/uri/is/invalid";
+        var hostUrl = new Uri("https://relative:789/uri/is/invalid");
         const string expectedHostUrl = "https://relative:789";
 
         // Act
@@ -311,9 +316,23 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     }
 
     [Fact]
+    public void When_creating_server_with_absolute_uri_it_should_not_throw_and_take_host_from_uri()
+    {
+        var hostUrl = new Uri("https://relative:789/uri/is/invalid");
+        var expectedHostUrl = new Uri("https://relative:789");
+
+        // Act
+        // ReSharper disable once ExpressionIsAlwaysNull
+        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUrl);
+
+        // Assert
+        act.Should().NotThrow().Which.HostUri.Should().Be(expectedHostUrl);
+    }
+
+    [Fact]
     public async Task Given_server_is_started_when_starting_again_it_should_throw()
     {
-        using var server = new MockHttpServer(_fixture.Handler, "http://127.0.0.1:0");
+        using var server = new MockHttpServer(_fixture.Handler, BaseUri);
         await server.StartAsync();
         server.IsStarted.Should().BeTrue();
 
@@ -327,7 +346,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     [Fact]
     public async Task Given_server_is_not_started_when_stopped_it_should_throw()
     {
-        using var server = new MockHttpServer(_fixture.Handler, "http://127.0.0.1:0");
+        using var server = new MockHttpServer(_fixture.Handler, BaseUri);
         server.IsStarted.Should().BeFalse();
 
         // Act
@@ -343,7 +362,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
         var handler = new MockHttpHandler();
 
         // Act
-        var server = new MockHttpServer(handler, "http://127.0.0.1:0");
+        var server = new MockHttpServer(handler, BaseUri);
 
         // Assert
         server.Handler.Should().Be(handler);

--- a/test/MockHttp.Testing/DelegateTestCase.cs
+++ b/test/MockHttp.Testing/DelegateTestCase.cs
@@ -9,7 +9,12 @@ public class DelegateTestCase : List<object?>
 
     private DelegateTestCase(Delegate @delegate)
     {
-        Name = @delegate.GetMethodInfo().Name;
+        if (@delegate is null)
+        {
+            throw new ArgumentNullException(nameof(@delegate));
+        }
+
+        Name = @delegate.GetMethodInfo()!.Name;
         Delegate = @delegate;
         Add(Name);
         Add(@delegate);
@@ -18,7 +23,7 @@ public class DelegateTestCase : List<object?>
     public IEnumerable<object?[]> GetNullArgumentTestCases(bool withoutName = false)
     {
         const int paramOffset = 2;
-        MethodInfo methodInfo = Delegate.GetMethodInfo();
+        MethodInfo methodInfo = Delegate.GetMethodInfo()!;
         ParameterInfo[] parameters = methodInfo.GetParameters();
         for (int i = paramOffset; i < Count; i++)
         {

--- a/test/MockHttp.Testing/NullArgumentTest.cs
+++ b/test/MockHttp.Testing/NullArgumentTest.cs
@@ -16,7 +16,7 @@ public static class NullArgumentTest
         string testCase = (string)testArgs[0];
         var func = (Delegate)testArgs[1];
         string expectedParamName = (string)testArgs[2];
-        ParameterInfo param = func.GetMethodInfo().GetParameters().Single(p => p.Name == expectedParamName);
+        ParameterInfo param = func.GetMethodInfo()!.GetParameters().Single(p => p.Name == expectedParamName);
         object[] args = testArgs.Skip(3).ToArray();
         if (args.Length == 0)
         {


### PR DESCRIPTION
* fix(CA2007): ConfigureAwait the task
* style(CA1819): properties should not return arrays
* style(CA1037): overload accepting StringComparison
* style(CA8602): suppress dereference possible null
* style(CA2000): suppress because it is registered for dispose
* style(CA2201): suppress
* style(CA1859): change interface type to concrete type for perf.
* style(CA1054,CA1056): change type of parameter from string to Uri.
  * The `MockHttpServer.HostUrl` is deprecated. Use `MockHttpServer.HostUri` instead.
  * The `MockHttpServer` ctors accepting `string` URL's are deprecated. Use the overloads accepting `System.Uri`.
* style(CA1861): prefer 'static readonly' fields over constant array args.
* style(CA1860): prefer comparing count to 0 rather using Any()
* style(CA5394): do not use insecure randomness
* style(CA1307,CA1309): Use ordinal string comparison