### PR TITLE
fix: address some static code analysis issues, exposed by the latest analyzer

### DIFF
--- a/src/MockHttp/Http/HttpHeaderEqualityComparer.cs
+++ b/src/MockHttp/Http/HttpHeaderEqualityComparer.cs
@@ -1,4 +1,5 @@
-﻿using MockHttp.Matchers.Patterns;
+﻿using System.ComponentModel;
+using MockHttp.Matchers.Patterns;
 
 namespace MockHttp.Http;
 
@@ -25,6 +26,11 @@ internal sealed class HttpHeaderEqualityComparer : IEqualityComparer<KeyValuePai
 
     public HttpHeaderEqualityComparer(HttpHeaderMatchType matchType)
     {
+        if (!Enum.IsDefined(typeof(HttpHeaderMatchType), matchType))
+        {
+            throw new InvalidEnumArgumentException(nameof(matchType), (int)matchType, typeof(HttpHeaderMatchType));
+        }
+
         _matchType = matchType;
     }
 
@@ -67,7 +73,7 @@ internal sealed class HttpHeaderEqualityComparer : IEqualityComparer<KeyValuePai
                 return !x.Value.Any();
             }
             default:
-                throw new ArgumentOutOfRangeException();
+                return false;
         }
     }
 

--- a/src/MockHttp/HttpMockException.cs
+++ b/src/MockHttp/HttpMockException.cs
@@ -35,6 +35,9 @@ public class HttpMockException : Exception
 
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
     protected HttpMockException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {

--- a/src/MockHttp/Responses/HttpHeaderBehavior.cs
+++ b/src/MockHttp/Responses/HttpHeaderBehavior.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Http.Headers;
-using MockHttp.Http;
+﻿using MockHttp.Http;
 
 namespace MockHttp.Responses;
 
@@ -57,10 +56,12 @@ internal sealed class HttpHeaderBehavior
         // Special case handling of headers which only allow single values.
         if (HeadersWithSingleValueOnly.Contains(header.Key))
         {
+            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
             if (responseMessage.Content?.Headers.TryGetValues(header.Key, out _) == true)
             {
                 responseMessage.Content.Headers.Remove(header.Key);
             }
+
             if (responseMessage.Headers.TryGetValues(header.Key, out _))
             {
                 responseMessage.Headers.Remove(header.Key);
@@ -68,27 +69,10 @@ internal sealed class HttpHeaderBehavior
         }
 
         // Try to add as message header first, if that fails, add as content header.
-        if (!TryAdd(responseMessage.Headers, header.Key, header.Value))
+        // Let it throw if not supported.
+        if (!responseMessage.Headers.TryAddWithoutValidation(header.Key, header.Value))
         {
             responseMessage.Content?.Headers.Add(header.Key, header.Value);
-        }
-    }
-
-    private static bool TryAdd(HttpHeaders? headers, string name, IEnumerable<string?> values)
-    {
-        if (headers is null)
-        {
-            return false;
-        }
-
-        try
-        {
-            headers.Add(name, values);
-            return true;
-        }
-        catch (Exception)
-        {
-            return false;
         }
     }
 }

--- a/test/MockHttp.Json.Tests/ArgAny.cs
+++ b/test/MockHttp.Json.Tests/ArgAny.cs
@@ -1,0 +1,13 @@
+﻿namespace MockHttp.Json;
+
+/// <summary>
+/// To deal with runtime API differences around mocking with nullable.
+/// </summary>
+internal static class ArgAny
+{
+#if NETCOREAPP3_1_OR_GREATER
+    public static ref string? String() => ref Arg.Any<string?>();
+#else
+    public static ref string String() => ref Arg.Any<string>();
+#endif
+}

--- a/test/MockHttp.Json.Tests/JsonContentMatcherTests.cs
+++ b/test/MockHttp.Json.Tests/JsonContentMatcherTests.cs
@@ -16,7 +16,7 @@ public sealed class JsonContentMatcherTests : IDisposable
 
         _equalityComparerMock = Substitute.For<IEqualityComparer<string>>();
         _equalityComparerMock
-            .Equals(Arg.Any<string?>(), Arg.Any<string?>())
+            .Equals(ArgAny.String(), ArgAny.String())
             .Returns(true);
 
         _requestMessage = new HttpRequestMessage();
@@ -43,7 +43,7 @@ public sealed class JsonContentMatcherTests : IDisposable
         // Assert
         _adapterMock.Received(1).Serialize(jsonContentAsObject);
         globalAdapterMock.DidNotReceiveWithAnyArgs().Serialize(Arg.Any<object?>());
-        _ = _equalityComparerMock.Received(1).Equals(Arg.Any<string?>(), serializedJson);
+        _ = _equalityComparerMock.Received(1).Equals(ArgAny.String(), serializedJson);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public sealed class JsonContentMatcherTests : IDisposable
 
         // Assert
         globalAdapterMock.Received(1).Serialize(jsonContentAsObject);
-        _ = _equalityComparerMock.Received(1).Equals(Arg.Any<string?>(), serializedJson);
+        _ = _equalityComparerMock.Received(1).Equals(ArgAny.String(), serializedJson);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public sealed class JsonContentMatcherTests : IDisposable
         await sut.IsMatchAsync(_requestContext);
 
         // Assert
-        _ = _equalityComparerMock.Received(1).Equals(Arg.Any<string?>(), serializedJson);
+        _ = _equalityComparerMock.Received(1).Equals(ArgAny.String(), serializedJson);
     }
 
     [Fact]
@@ -104,14 +104,14 @@ public sealed class JsonContentMatcherTests : IDisposable
         var sut = new JsonContentMatcher("something to compare with", _adapterMock, _equalityComparerMock);
 
         _equalityComparerMock
-            .Equals(Arg.Any<string?>(), Arg.Any<string?>())
+            .Equals(ArgAny.String(), ArgAny.String())
             .Returns(equals);
 
         // Act
         bool actual = await sut.IsMatchAsync(_requestContext);
 
         // Assert
-        _ =_equalityComparerMock.Received(1).Equals(Arg.Any<string?>(), Arg.Any<string?>());
+        _ =_equalityComparerMock.Received(1).Equals(ArgAny.String(), ArgAny.String());
         actual.Should().Be(equals);
     }
 
@@ -131,7 +131,7 @@ public sealed class JsonContentMatcherTests : IDisposable
             await sut.IsMatchAsync(_requestContext);
 
             // Assert
-            _ = _equalityComparerMock.Received(1).Equals(string.Empty, Arg.Any<string?>());
+            _ = _equalityComparerMock.Received(1).Equals(string.Empty, ArgAny.String());
         }
     }
 
@@ -169,6 +169,7 @@ public sealed class JsonContentMatcherTests : IDisposable
 
     public void Dispose()
     {
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
         _requestMessage?.Dispose();
     }
 }

--- a/test/MockHttp.Tests/Language/Flow/Response/HeaderSpec.cs
+++ b/test/MockHttp.Tests/Language/Flow/Response/HeaderSpec.cs
@@ -6,14 +6,8 @@ namespace MockHttp.Language.Flow.Response;
 
 public class HeaderSpec : ResponseSpec
 {
-    private readonly DateTimeOffset _utcNow;
-    private readonly DateTime _now;
-
-    public HeaderSpec()
-    {
-        _utcNow = DateTimeOffset.UtcNow;
-        _now = DateTime.Now;
-    }
+    private readonly DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+    private readonly DateTime _now = DateTime.Now;
 
     protected override void Given(IResponseBuilder with)
     {
@@ -42,6 +36,8 @@ public class HeaderSpec : ResponseSpec
             .And.HaveHeader("X-Date", new[] { _now.AddYears(-1).ToString("R"), _now.ToString("R") })
             .And.HaveHeader("X-Empty", string.Empty)
             .And.HaveHeader("X-Null", string.Empty);
+        response.Headers.Count().Should().Be(5);
+        response.Content.Headers.Count().Should().Be(2);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
* refactor(CA2208): throw invalid enum exception in ctor to satisfy static code analysis.
* fix(SYSLIB0051): mark serializable/binary formatter support as obsolete
* refactor(CA1031): use `TryAddWithoutValidation` to avoid exceptions and to skip adding header if not supported.
* fix(CA2007): use `ConfigureAwait` on awaitable async stream
* test(CS8604): in older runtimes, IEqualityComparer<> did not use nullable annotation. Fix with string polyfill for Arg.Any.


