### PR TITLE
feat(server): implement `IAsyncDisposable` on `HttpMockServer`

### DIFF
--- a/test/MockHttp.Server.Tests/Fixtures/MockHttpServerFixture.cs
+++ b/test/MockHttp.Server.Tests/Fixtures/MockHttpServerFixture.cs
@@ -68,7 +68,7 @@ public class MockHttpServerFixture : IDisposable, IAsyncLifetime
 
     public Task DisposeAsync()
     {
-        return Server.StopAsync();
+        return Server.DisposeAsync().AsTask();
     }
 
     private static bool SupportsIpv6()


### PR DESCRIPTION
Added `IAsyncDisposable` to asynchronously dispose `HttpMockServer` and the internal host.