### PR TITLE
fix: setting any content header (specifically) after setting JSON body resets HttpContent to empty

### DIFF
--- a/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
+++ b/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
@@ -1,0 +1,19 @@
+﻿using MockHttp.Responses;
+
+namespace MockHttp.Language.Flow.Response;
+
+internal sealed class EnsureHttpContentBehavior
+    : IResponseBehavior
+{
+    public Task HandleAsync
+    (
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate next,
+        CancellationToken cancellationToken)
+    {
+        // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+        responseMessage.Content ??= new EmptyContent();
+        return next(requestContext, responseMessage, cancellationToken);
+    }
+}

--- a/test/MockHttp.Json.Tests/Issues/Issue98.cs
+++ b/test/MockHttp.Json.Tests/Issues/Issue98.cs
@@ -1,0 +1,45 @@
+﻿using System.Net;
+using System.Text;
+using MockHttp.FluentAssertions;
+using Newtonsoft.Json;
+
+namespace MockHttp.Json.Issues;
+
+public class Issue98
+{
+    [Fact]
+    public async Task When_setting_content_header_after_setting_jsonBody_it_should_return_expected_response()
+    {
+        using var mockHttp = new MockHttpHandler();
+        mockHttp
+            .When(m => m
+                .Method(HttpMethod.Post)
+                .RequestUri("api/login")
+                .ContentType("application/json; charset=utf-8")
+                .JsonBody(new { username = @"corp\user", password = "Super.Mari0.Bro$$" })
+            )
+            .Respond(r => r
+                .StatusCode(HttpStatusCode.OK)
+                .JsonBody(new { username = "user@corp" }, Encoding.UTF8)
+                .Header("Set-Cookie",
+                    "session=abcdefghi==; Expires=Tue, 01 Feb 2024 01:01:01 GMT; Secure; HttpOnly; Path=/")
+            )
+            .Verifiable();
+
+        var client = new HttpClient(mockHttp)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+        // Act
+        HttpResponseMessage? response = await client.PostAsJsonAsync("api/login", new { username = @"corp\user", password = @"Super.Mari0.Bro$$" });
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.Headers.Should()
+            .ContainKey("Set-Cookie",
+                "session=abcdefghi==; Expires=Tue, 01 Feb 2024 01:01:01 GMT; Secure; HttpOnly; Path=/");
+        response.Should().HaveContentType("application/json; charset=utf-8");
+        await response.Should().HaveContentAsync(JsonConvert.SerializeObject(new { username = "user@corp" }), Encoding.UTF8);
+        mockHttp.Verify();
+    }
+}


### PR DESCRIPTION
When setting any content header after setting the `HttpContent` with the `.JsonBody()`-extension (or any other custom `IResponseBehavior`) it would reset the `HttpContent` to an empty content, undoing the user added content.

Fixed by preemptively setting the `HttpResponseMessage.Content` to an empty content before any user registered behaviors run, instead of checking for a specific behavior type. This was brittle because it depended on a specific implementation type check which the `JsonContentBehavior` did not satisfy.

Fixes #98