### PR TITLE
fix(CA1031): use exception handler middleware instead of catching all exceptions in ServerRequestHandler

### DIFF
--- a/src/MockHttp.Server/MockHttpServer.cs
+++ b/src/MockHttp.Server/MockHttpServer.cs
@@ -225,6 +225,8 @@ public sealed class MockHttpServer
 
                 AddMockHttpServerHeader(applicationBuilder);
 
+                applicationBuilder.UseMockHttpExceptionHandler();
+
                 ServerRequestHandler serverRequestHandler = applicationBuilder.ApplicationServices.GetRequiredService<ServerRequestHandler>();
                 applicationBuilder.Use(serverRequestHandler.HandleAsync);
             });

--- a/src/MockHttp.Server/Server/ExceptionHandler.cs
+++ b/src/MockHttp.Server/Server/ExceptionHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MockHttp.Http;
+
+namespace MockHttp.Server;
+
+internal static class ExceptionHandler
+{
+    internal static IApplicationBuilder UseMockHttpExceptionHandler(this IApplicationBuilder app)
+    {
+        return app.UseExceptionHandler(new ExceptionHandlerOptions { ExceptionHandler = HandleExceptionAsync });
+    }
+
+    private static Task HandleExceptionAsync(HttpContext ctx)
+    {
+        if (ctx.Response.HasStarted)
+        {
+            return Task.CompletedTask;
+        }
+
+        Exception? ex = ctx.Features.Get<IExceptionHandlerFeature>()?.Error;
+        ILogger logger = ctx.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(ExceptionHandler).FullName!);
+        logger.LogRequestMessage(ctx, Resources.Error_VerifyMockSetup);
+
+        ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+
+        IHttpResponseFeature? responseFeature = ctx.Features.Get<IHttpResponseFeature>();
+        if (responseFeature is not null)
+        {
+            responseFeature.ReasonPhrase = Resources.Error_VerifyMockSetup;
+        }
+
+        ctx.Response.ContentType = $"{MediaTypes.PlainText}; charset={MockHttpHandler.DefaultEncoding.WebName}";
+        byte[] body = MockHttpHandler.DefaultEncoding.GetBytes(Resources.Error_VerifyMockSetup + Environment.NewLine + ex);
+        return ctx.Response.BodyWriter.WriteAsync(body, ctx.RequestAborted).AsTask();
+    }
+}

--- a/src/MockHttp.Server/Server/ServerRequestHandler.cs
+++ b/src/MockHttp.Server/Server/ServerRequestHandler.cs
@@ -1,9 +1,6 @@
-﻿using System.Net;
-using System.Text;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
-using MockHttp.Http;
 
 namespace MockHttp.Server;
 
@@ -38,18 +35,6 @@ internal class ServerRequestHandler : DelegatingHandler
         {
             httpResponseMessage = await SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
-        {
-            _logger.LogRequestMessage(httpContext, Resources.Error_VerifyMockSetup);
-
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            httpResponseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError)
-#pragma warning restore CA2000 // Dispose objects before losing scope
-            {
-                ReasonPhrase = Resources.Error_VerifyMockSetup,
-                Content = new StringContent(Resources.Error_VerifyMockSetup + Environment.NewLine + ex, MockHttpHandler.DefaultEncoding, MediaTypes.PlainText)
-            };
-        }
         finally
         {
             _logger.LogRequestMessage(httpContext, Resources.Debug_RequestHandled);
@@ -65,6 +50,7 @@ internal class ServerRequestHandler : DelegatingHandler
         {
             throw new InvalidOperationException(Resources.MissingHttpResponseFeature);
         }
+
         await httpResponseMessage.MapToFeatureAsync(responseFeature, responseBodyFeature, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/test/MockHttp.Server.Tests/MockHttpServerTests.cs
+++ b/test/MockHttp.Server.Tests/MockHttpServerTests.cs
@@ -232,8 +232,27 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.InternalServerError);
+        response.Should().HaveContentType(MediaTypes.PlainText, Encoding.UTF8);
         await response.Should().HaveContentAsync(expectedErrorMessage + Environment.NewLine + ex);
         response.ReasonPhrase.Should().Be(expectedErrorMessage);
+        _fixture.Handler.Verify();
+    }
+
+    [Fact]
+    public async Task Given_that_request_is_configured_with_server_timeout_when_sending_it_should_respond_with_request_timed_out()
+    {
+        _fixture.Handler
+            .When(matching => matching.Method(HttpMethod.Get))
+            .Respond(with => with.ServerTimeout())
+            .Verifiable();
+
+        using HttpClient client = _fixture.Server.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("");
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.RequestTimeout);
         _fixture.Handler.Verify();
     }
 


### PR DESCRIPTION
Fix CA1031 warning. This also avoids unnecessary allocation of new `HttpResponseMessage`.