### PR TITLE
chore(deps): bump System.Text.Json from 5.0.2 to 6.0.11

### DIFF
--- a/src/MockHttp.Json/MockHttp.Json.csproj
+++ b/src/MockHttp.Json/MockHttp.Json.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="$(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" Condition="$(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
+    <PackageReference Include="System.Text.Json" Version="6.0.11" Condition="$(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MockHttp.Json.Tests/MockHttp.Json.Tests.csproj
+++ b/test/MockHttp.Json.Tests/MockHttp.Json.Tests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MockHttp.Testing\MockHttp.Testing.csproj" />
     <!-- For coverage purposes, override default dependency resolution and instead target specific frameworks. -->
     <ProjectReference Include="..\..\src\MockHttp.Json\MockHttp.Json.csproj" Condition="'$(TestNetStandard20)'=='' And '$(TestNetStandard21)'==''" />


### PR DESCRIPTION
5.0.2 is officially deprecated.

Related to #136