### PR TITLE
fix(CA1716)!: do not use reserved language keyword 'Next'

### DIFF
--- a/src/MockHttp.Json/Extensions/ResponseBuilderExtensions.cs
+++ b/src/MockHttp.Json/Extensions/ResponseBuilderExtensions.cs
@@ -71,7 +71,12 @@ public static class ResponseBuilderExtensions
             _adapter = adapter;
         }
 
-        public Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+        public Task HandleAsync(
+            MockHttpRequestContext requestContext,
+            HttpResponseMessage responseMessage,
+            ResponseHandlerDelegate nextHandler,
+            CancellationToken cancellationToken
+        )
         {
             IJsonAdapter jsonSerializerAdapter = _adapter ?? requestContext.GetAdapter();
             object? value = _jsonContentFactory();
@@ -84,7 +89,7 @@ public static class ResponseBuilderExtensions
                 }
             };
 
-            return next(requestContext, responseMessage, cancellationToken);
+            return nextHandler(requestContext, responseMessage, cancellationToken);
         }
     }
 }

--- a/src/MockHttp/Internal/Response/Behaviors/HttpContentBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/HttpContentBehavior.cs
@@ -12,9 +12,14 @@ internal sealed class HttpContentBehavior
         _httpContentFactory = httpContentFactory ?? throw new ArgumentNullException(nameof(httpContentFactory));
     }
 
-    public async Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public async Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
         responseMessage.Content = await _httpContentFactory(cancellationToken).ConfigureAwait(false);
-        await next(requestContext, responseMessage, cancellationToken).ConfigureAwait(false);
+        await nextHandler(requestContext, responseMessage, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MockHttp/Internal/Response/Behaviors/HttpHeaderBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/HttpHeaderBehavior.cs
@@ -37,7 +37,12 @@ internal sealed class HttpHeaderBehavior
         _headers = headers?.ToList() ?? throw new ArgumentNullException(nameof(headers));
     }
 
-    public Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
         // ReSharper disable once UseDeconstruction
         foreach (KeyValuePair<string, IEnumerable<string?>> header in _headers)
@@ -45,7 +50,7 @@ internal sealed class HttpHeaderBehavior
             Add(header, responseMessage);
         }
 
-        return next(requestContext, responseMessage, cancellationToken);
+        return nextHandler(requestContext, responseMessage, cancellationToken);
     }
 
     /// <summary>

--- a/src/MockHttp/Internal/Response/Behaviors/NetworkLatencyBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/NetworkLatencyBehavior.cs
@@ -12,8 +12,13 @@ internal sealed class NetworkLatencyBehavior
         _networkLatency = networkLatency ?? throw new ArgumentNullException(nameof(networkLatency));
     }
 
-    public Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
-        return _networkLatency.SimulateAsync(() => next(requestContext, responseMessage, cancellationToken), cancellationToken);
+        return _networkLatency.SimulateAsync(() => nextHandler(requestContext, responseMessage, cancellationToken), cancellationToken);
     }
 }

--- a/src/MockHttp/Internal/Response/Behaviors/StatusCodeBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/StatusCodeBehavior.cs
@@ -20,7 +20,12 @@ internal sealed class StatusCodeBehavior
         _reasonPhrase = reasonPhrase;
     }
 
-    public Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
         responseMessage.StatusCode = _statusCode;
         if (_reasonPhrase is not null)
@@ -28,6 +33,6 @@ internal sealed class StatusCodeBehavior
             responseMessage.ReasonPhrase = _reasonPhrase;
         }
 
-        return next(requestContext, responseMessage, cancellationToken);
+        return nextHandler(requestContext, responseMessage, cancellationToken);
     }
 }

--- a/src/MockHttp/Internal/Response/Behaviors/TimeoutBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/TimeoutBehavior.cs
@@ -19,7 +19,12 @@ internal sealed class TimeoutBehavior
         _timeoutAfter = timeoutAfter;
     }
 
-    public Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
         // It is somewhat unintuitive to throw TaskCanceledException but this is what HttpClient does,
         // so we simulate same behavior.

--- a/src/MockHttp/Internal/Response/Behaviors/TransferRateBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/TransferRateBehavior.cs
@@ -18,9 +18,14 @@ internal sealed class TransferRateBehavior : IResponseBehavior
         _bitRate = bitRate;
     }
 
-    public async Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken)
+    public async Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
-        await next(requestContext, responseMessage, cancellationToken).ConfigureAwait(false);
+        await nextHandler(requestContext, responseMessage, cancellationToken).ConfigureAwait(false);
         responseMessage.Content = new RateLimitedHttpContent(responseMessage.Content, _bitRate);
     }
 

--- a/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
+++ b/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
@@ -6,15 +6,15 @@ namespace MockHttp.Language.Flow.Response;
 internal sealed class EnsureHttpContentBehavior
     : IResponseBehavior
 {
-    public Task HandleAsync
-    (
+    public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate next,
-        CancellationToken cancellationToken)
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    )
     {
         // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
         responseMessage.Content ??= new EmptyContent();
-        return next(requestContext, responseMessage, cancellationToken);
+        return nextHandler(requestContext, responseMessage, cancellationToken);
     }
 }

--- a/src/MockHttp/Responses/IResponseBehavior.cs
+++ b/src/MockHttp/Responses/IResponseBehavior.cs
@@ -12,12 +12,18 @@ public delegate Task ResponseHandlerDelegate(MockHttpRequestContext requestConte
 public interface IResponseBehavior
 {
     /// <summary>
-    /// Executes the behavior. Call <paramref name="next" /> to execute the next behavior in the response pipeline and use its returned response message.
+    /// Executes the behavior. Call <paramref name="nextHandler" /> to execute the next behavior in the response pipeline and use its returned
+    /// response message.
     /// </summary>
     /// <param name="requestContext">The current request context.</param>
     /// <param name="responseMessage">The response message.</param>
-    /// <param name="next">The next behavior.</param>
+    /// <param name="nextHandler">The next handler.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An awaitable that upon completion returns the HTTP response message.</returns>
-    Task HandleAsync(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, ResponseHandlerDelegate next, CancellationToken cancellationToken);
+    Task HandleAsync(
+        MockHttpRequestContext requestContext,
+        HttpResponseMessage responseMessage,
+        ResponseHandlerDelegate nextHandler,
+        CancellationToken cancellationToken
+    );
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_8.0.verified.txt
@@ -484,7 +484,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.8.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.8.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {

--- a/test/MockHttp.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.1.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.1.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {

--- a/test/MockHttp.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate next, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {


### PR DESCRIPTION
Renamed the method argument `next` to `nextHandler` to satisfy rule [CA1716](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716).