### PR TITLE
fix(CA1711)!: delegate names should not end with Delegate.

### DIFF
--- a/src/MockHttp.Json/Extensions/ResponseBuilderExtensions.cs
+++ b/src/MockHttp.Json/Extensions/ResponseBuilderExtensions.cs
@@ -74,7 +74,7 @@ public static class ResponseBuilderExtensions
         public Task HandleAsync(
             MockHttpRequestContext requestContext,
             HttpResponseMessage responseMessage,
-            ResponseHandlerDelegate nextHandler,
+            ResponseHandler nextHandler,
             CancellationToken cancellationToken
         )
         {

--- a/src/MockHttp/Internal/Response/Behaviors/HttpContentBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/HttpContentBehavior.cs
@@ -15,7 +15,7 @@ internal sealed class HttpContentBehavior
     public async Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Internal/Response/Behaviors/HttpHeaderBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/HttpHeaderBehavior.cs
@@ -40,7 +40,7 @@ internal sealed class HttpHeaderBehavior
     public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Internal/Response/Behaviors/NetworkLatencyBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/NetworkLatencyBehavior.cs
@@ -15,7 +15,7 @@ internal sealed class NetworkLatencyBehavior
     public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Internal/Response/Behaviors/StatusCodeBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/StatusCodeBehavior.cs
@@ -23,7 +23,7 @@ internal sealed class StatusCodeBehavior
     public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Internal/Response/Behaviors/TimeoutBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/TimeoutBehavior.cs
@@ -22,7 +22,7 @@ internal sealed class TimeoutBehavior
     public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Internal/Response/Behaviors/TransferRateBehavior.cs
+++ b/src/MockHttp/Internal/Response/Behaviors/TransferRateBehavior.cs
@@ -21,7 +21,7 @@ internal sealed class TransferRateBehavior : IResponseBehavior
     public async Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
+++ b/src/MockHttp/Language/Flow/Response/EnsureHttpContentBehavior.cs
@@ -9,7 +9,7 @@ internal sealed class EnsureHttpContentBehavior
     public Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     )
     {

--- a/src/MockHttp/Language/Flow/Response/ResponseBuilder.cs
+++ b/src/MockHttp/Language/Flow/Response/ResponseBuilder.cs
@@ -96,8 +96,14 @@ internal sealed class ResponseBuilder
             };
 
             await _invertedBehaviors
-                .Aggregate((ResponseHandlerDelegate)Seed,
-                    (next, pipeline) => (context, message, ct) => pipeline.HandleAsync(context, message, next, ct)
+                .Aggregate(
+                    (ResponseHandler)Seed,
+                    (next, pipeline) => (context, message, ct) => pipeline.HandleAsync(
+                        context,
+                        message,
+                        next,
+                        ct
+                    )
                 )(requestContext, response, cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/MockHttp/Responses/IResponseBehavior.cs
+++ b/src/MockHttp/Responses/IResponseBehavior.cs
@@ -4,7 +4,11 @@
 /// A delegate which when executed returns a configured HTTP response.
 /// </summary>
 /// <returns></returns>
-public delegate Task ResponseHandlerDelegate(MockHttpRequestContext requestContext, HttpResponseMessage responseMessage, CancellationToken cancellationToken);
+public delegate Task ResponseHandler(
+    MockHttpRequestContext requestContext,
+    HttpResponseMessage responseMessage,
+    CancellationToken cancellationToken
+);
 
 /// <summary>
 /// Describes a way to apply a response behavior in a response builder pipeline.
@@ -23,7 +27,7 @@ public interface IResponseBehavior
     Task HandleAsync(
         MockHttpRequestContext requestContext,
         HttpResponseMessage responseMessage,
-        ResponseHandlerDelegate nextHandler,
+        ResponseHandler nextHandler,
         CancellationToken cancellationToken
     );
 }

--- a/test/MockHttp.Tests/Internal/Response/Behaviors/TimeoutBehaviorTests.cs
+++ b/test/MockHttp.Tests/Internal/Response/Behaviors/TimeoutBehaviorTests.cs
@@ -16,7 +16,7 @@ public class TimeoutBehaviorTests
         var timeout = TimeSpan.FromMilliseconds(timeoutInMilliseconds);
         var sut = new TimeoutBehavior(timeout);
         var sw = new Stopwatch();
-        ResponseHandlerDelegate nextStub = Substitute.For<ResponseHandlerDelegate>();
+        ResponseHandler nextStub = Substitute.For<ResponseHandler>();
 
         // Act
         Func<Task> act = () => sut.HandleAsync(
@@ -45,7 +45,7 @@ public class TimeoutBehaviorTests
         var timeout = TimeSpan.FromSeconds(60);
         var sut = new TimeoutBehavior(timeout);
         var ct = new CancellationToken(true);
-        ResponseHandlerDelegate nextStub = Substitute.For<ResponseHandlerDelegate>();
+        ResponseHandler nextStub = Substitute.For<ResponseHandler>();
 
         // Act
         var sw = Stopwatch.StartNew();

--- a/test/MockHttp.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_8.0.verified.txt
@@ -484,7 +484,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -497,5 +497,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -496,5 +496,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -496,5 +496,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_Framework_4.8.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Framework_4.8.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -496,5 +496,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.1.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.1.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -496,5 +496,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }

--- a/test/MockHttp.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
+++ b/test/MockHttp.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
@@ -483,7 +483,7 @@ namespace MockHttp.Responses
 {
     public interface IResponseBehavior
     {
-        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandlerDelegate nextHandler, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task HandleAsync(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, MockHttp.Responses.ResponseHandler nextHandler, System.Threading.CancellationToken cancellationToken);
     }
     public interface IResponseStrategy
     {
@@ -496,5 +496,5 @@ namespace MockHttp.Responses
         public System.Collections.Generic.IReadOnlyDictionary<System.Type, object> Services { get; }
         public bool TryGetService<TService>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TService? service) { }
     }
-    public delegate System.Threading.Tasks.Task ResponseHandlerDelegate(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task ResponseHandler(MockHttp.Responses.MockHttpRequestContext requestContext, System.Net.Http.HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Renamed `ResponseHandlerDelegate` to `ResponseHandler` to satisfy [CA1711](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1711).