### PR TITLE
chore!: remove obsolete MockHttpServer overloads

### DIFF
--- a/src/MockHttp.Server/MockHttpServer.cs
+++ b/src/MockHttp.Server/MockHttpServer.cs
@@ -32,18 +32,8 @@ public sealed class MockHttpServer
     private IWebHost? _host;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to listen on specified <paramref name="hostUrl" />.
-    /// </summary>
-    /// <param name="mockHttpHandler">The mock http handler.</param>
-    /// <param name="hostUrl">The host URL the mock HTTP server will listen on.</param>
-    [Obsolete("Use the overload accepting an System.Uri.")]
-    public MockHttpServer(MockHttpHandler mockHttpHandler, string hostUrl)
-        : this(mockHttpHandler, GetHostUrl(hostUrl))
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to listen on specified <paramref name="hostUri" />.
+    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to
+    /// listen on specified <paramref name="hostUri" />.
     /// </summary>
     /// <param name="mockHttpHandler">The mock http handler.</param>
     /// <param name="hostUri">The host URI the mock HTTP server will listen on.</param>
@@ -53,25 +43,19 @@ public sealed class MockHttpServer
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to listen on specified <paramref name="hostUrl" />.
-    /// </summary>
-    /// <param name="mockHttpHandler">The mock http handler.</param>
-    /// <param name="loggerFactory">The logger factory to use to log pipeline requests to.</param>
-    /// <param name="hostUrl">The host URL the mock HTTP server will listen on.</param>
-    [Obsolete("Use the overload accepting an System.Uri.")]
-    public MockHttpServer(MockHttpHandler mockHttpHandler, ILoggerFactory? loggerFactory, string hostUrl)
-        : this(mockHttpHandler, loggerFactory, GetHostUrl(hostUrl))
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to listen on specified <paramref name="hostUri" />.
+    /// Initializes a new instance of the <see cref="MockHttpServer" /> using specified <paramref name="mockHttpHandler" /> and configures it to
+    /// listen on specified <paramref name="hostUri" />.
     /// </summary>
     /// <param name="mockHttpHandler">The mock http handler.</param>
     /// <param name="loggerFactory">The logger factory to use to log pipeline requests to.</param>
     /// <param name="hostUri">The host URI the mock HTTP server will listen on.</param>
     public MockHttpServer(MockHttpHandler mockHttpHandler, ILoggerFactory? loggerFactory, Uri hostUri)
     {
+        if (hostUri is null)
+        {
+            throw new ArgumentNullException(nameof(hostUri));
+        }
+
         Handler = mockHttpHandler ?? throw new ArgumentNullException(nameof(mockHttpHandler));
         _webHostBuilder = CreateWebHostBuilder(loggerFactory);
         _hostUri = new Uri(hostUri, "/"); // Ensure base URL.
@@ -101,14 +85,6 @@ public sealed class MockHttpServer
     /// Gets the <see cref="MockHttpHandler" /> that is simulating middleware.
     /// </summary>
     public MockHttpHandler Handler { get; }
-
-    /// <summary>
-    /// Gets the host URL the mock HTTP server will listen on.
-    /// </summary>
-    [Obsolete("Use the HostUri instead.")]
-#pragma warning disable CA1056 // URI-like properties should not be strings
-    public string HostUrl => HostUri.ToString().TrimEnd('/');
-#pragma warning restore CA1056 // URI-like properties should not be strings
 
     /// <summary>
     /// Gets the host URI the mock HTTP server will listen on.
@@ -235,18 +211,6 @@ public sealed class MockHttpServer
     internal void Configure(Action<IApplicationBuilder> configureAppBuilder)
     {
         _configureAppBuilder = configureAppBuilder;
-    }
-
-    private static Uri GetHostUrl(string hostUrl)
-    {
-        if (hostUrl is null)
-        {
-            throw new ArgumentNullException(nameof(hostUrl));
-        }
-
-        return Uri.TryCreate(hostUrl, UriKind.Absolute, out Uri? uri)
-            ? uri
-            : throw new ArgumentException(Resources.Error_HostUrlIsNotValid, nameof(hostUrl));
     }
 
     private void AddMockHttpServerHeader(IApplicationBuilder applicationBuilder)

--- a/src/MockHttp.Server/Resources.Designer.cs
+++ b/src/MockHttp.Server/Resources.Designer.cs
@@ -79,15 +79,6 @@ namespace MockHttp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify a host URL..
-        /// </summary>
-        internal static string Error_HostUrlIsNotValid {
-            get {
-                return ResourceManager.GetString("Error_HostUrlIsNotValid", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to MockHttpServer failed to handle request. Please verify your mock setup is correct..
         /// </summary>
         internal static string Error_VerifyMockSetup {

--- a/src/MockHttp.Server/Resources.resx
+++ b/src/MockHttp.Server/Resources.resx
@@ -129,9 +129,6 @@
   <data name="Debug_HandlingRequest" xml:space="preserve">
     <value>MockHttpServer received request.</value>
   </data>
-  <data name="Error_HostUrlIsNotValid" xml:space="preserve">
-    <value>Specify a host URL.</value>
-  </data>
   <data name="MissingHttpResponseFeature" xml:space="preserve">
     <value>HTTP response feature missing.</value>
   </data>

--- a/test/MockHttp.Server.Tests/MockHttpServerTests.cs
+++ b/test/MockHttp.Server.Tests/MockHttpServerTests.cs
@@ -169,7 +169,7 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
         // Act
 #pragma warning disable CS0618
 #pragma warning disable SYSLIB0014 // Type or member is obsolete - justification: testing other API's
-        var request = WebRequest.Create($"{_fixture.Server.HostUrl}/web-request");
+        var request = WebRequest.Create($"{_fixture.Server.HostUri}web-request");
 #pragma warning restore SYSLIB0014 // Type or member is obsolete
 #pragma warning restore CS0618
         request.Method = "POST";
@@ -286,50 +286,31 @@ public sealed class MockHttpServerTests : IClassFixture<MockHttpServerFixture>, 
     }
 
     [Fact]
-    [Obsolete("Removed in next major version.")]
     public void When_creating_server_with_null_host_it_should_throw()
     {
-        string? hostUrl = null;
+        Uri? hostUri = null;
 
         // Act
-#pragma warning disable CS8604
-        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUrl);
-#pragma warning restore CS8604
+        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUri!);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>().WithParameterName(nameof(hostUrl));
+        act.Should().Throw<ArgumentNullException>().WithParameterName(nameof(hostUri));
     }
 
     [Fact]
-    [Obsolete("Removed in next major version.")]
-    public void When_creating_server_with_invalid_host_it_should_throw()
-    {
-        const string hostUrl = "relative/uri/is/invalid";
-
-        // Act
-        // ReSharper disable once ExpressionIsAlwaysNull
-        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUrl);
-
-        // Assert
-        act.Should().Throw<ArgumentException>().WithParameterName(nameof(hostUrl));
-    }
-
-    [Fact]
-    [Obsolete("Removed in next major version.")]
     public async Task When_creating_server_with_absolute_uri_it_should_not_throw_and_take_host_from_url()
     {
-        var hostUrl = new Uri("https://relative:789/uri/is/invalid");
+        var hostUri = new Uri("https://relative:789/uri/is/invalid");
         const string expectedHostUrl = "https://relative:789";
 
         // Act
-        // ReSharper disable once ExpressionIsAlwaysNull
-        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUrl);
+        Func<MockHttpServer> act = () => new MockHttpServer(new MockHttpHandler(), hostUri);
 
         // Assert
         MockHttpServer server = act.Should().NotThrow().Which;
         await using (server)
         {
-            act.Should().NotThrow().Which.HostUrl.Should().Be(expectedHostUrl);
+            act.Should().NotThrow().Which.HostUri.Should().Be(expectedHostUrl);
         }
     }
 

--- a/test/MockHttp.Server.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/MockHttp.Server.Tests/PublicApi/.NET_8.0.verified.txt
@@ -6,15 +6,9 @@ namespace MockHttp
     public sealed class MockHttpServer : System.IAsyncDisposable, System.IDisposable
     {
         public MockHttpServer(MockHttp.MockHttpHandler mockHttpHandler, System.Uri hostUri) { }
-        [System.Obsolete("Use the overload accepting an System.Uri.")]
-        public MockHttpServer(MockHttp.MockHttpHandler mockHttpHandler, string hostUrl) { }
         public MockHttpServer(MockHttp.MockHttpHandler mockHttpHandler, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, System.Uri hostUri) { }
-        [System.Obsolete("Use the overload accepting an System.Uri.")]
-        public MockHttpServer(MockHttp.MockHttpHandler mockHttpHandler, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, string hostUrl) { }
         public MockHttp.MockHttpHandler Handler { get; }
         public System.Uri HostUri { get; }
-        [System.Obsolete("Use the HostUri instead.")]
-        public string HostUrl { get; }
         public bool IsStarted { get; }
         public System.Net.Http.HttpClient CreateClient() { }
         public void Dispose() { }


### PR DESCRIPTION
These `MockHttpServer` overloads have been obsolete for more than a year and can be removed for next major release.